### PR TITLE
Change print color for ::first-letter and ::first-line pseudo-elements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+### HEAD
+
+* Change print color for ::first-letter and ::first-line pseudo-elements
+  ([#1715](https://github.com/h5bp/html5-boilerplate/pull/1715)).
+
 ### 5.2.0 (May 1, 2015)
 
 * Update jQuery to `v1.11.3`

--- a/dist/css/main.css
+++ b/dist/css/main.css
@@ -211,7 +211,9 @@ textarea {
 @media print {
     *,
     *:before,
-    *:after {
+    *:after,
+    *:first-letter,
+    *:first-line {
         background: transparent !important;
         color: #000 !important; /* Black prints faster:
                                    http://www.sanbeiji.com/archives/953 */

--- a/src/css/main.css
+++ b/src/css/main.css
@@ -203,7 +203,9 @@ textarea {
 @media print {
     *,
     *:before,
-    *:after {
+    *:after,
+    *:first-letter,
+    *:first-line {
         background: transparent !important;
         color: #000 !important; /* Black prints faster:
                                    http://www.sanbeiji.com/archives/953 */


### PR DESCRIPTION
Pseudo-elements `::first-letter` and `::first-line` now get printed
black by default as `::before` and `::after` are.

All pseudo-elements:
https://developer.mozilla.org/en-US/docs/Web/CSS/Pseudo-elements

Closes #1715.